### PR TITLE
Fix typo in README

### DIFF
--- a/MaTableGPT-main/README.md
+++ b/MaTableGPT-main/README.md
@@ -50,7 +50,7 @@ MaTableGPT
 ### 4) Code usage (run.py)
 **Examples : Input generation (split, tsv)**
 > ```python
-> input_guneration("split", "TSV")
+> input_generation("split", "TSV")
 > ```
 
 **Examples : Data extraction (few shot, follow_up questions)**


### PR DESCRIPTION
## Summary
- correct `input_guneration` typo in MaTableGPT README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b7ce561b0832bb9c5a6b5d90dec22