### PR TITLE
Adapt extractor for ligand data

### DIFF
--- a/MaTableGPT-main/GPT_models/models.py
+++ b/MaTableGPT-main/GPT_models/models.py
@@ -19,7 +19,7 @@ def fine_tuning(input_path, output_path):
     json : prediction of table data extraction
     """     
 
-    client = OpenAI(api_key = "User key" ) 
+    client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
     file_list = os.listdir(input_path)
 
     response = []
@@ -33,7 +33,7 @@ def fine_tuning(input_path, output_path):
             model="FINE TUNED MODEL",
             temperature=0,
             messages=[
-            {"role": "system", "content": "this task is to take a string as input and convert it to json format. I want to extract the performance below. [reaction_type, versus, overpotential, substrate, loading, tafel_slope, onset_potential, current_density, BET, specific_activity, mass_activity, surface_area, ECSA, apparent_activation_energy, water_splitting_potential, potential, Rs, Rct, Cdl, TOF, stability, electrolyte, exchange_current_density, onset_overpotential]. If there is information about overpotential and Tafel slope in the input, the output should be generated as follows.\n\n{\n\u201dcatalyst_name\": {\n\"overpotential\": {\n\"electrolyte\": \"1.0 M KOH\",\n\"reaction_type\": \"OER\",\n\"value\": \"230 mV\",\n\"current_density\": \"50 mA/cm2\"\n},\n\"tafel_slope\": {\n\"electrolyte\": \"1.0 M KOH\",\n\"reaction_type\": \"OER\",\n\"value\": \"54 mV/dec\"\n}\n\n}\n\n}\n\nIf information regarding the reaction_type or electrolyte cannot be found in the input, they should not be included in the output as follows.\n\n{\n\u201dcatalyst_name\": {\n\"overpotential\": {\n\"value\": \"230 mV\",\n\"current_density\": \"50 mA/cm2\"\n},\n\"tafel_slope\": {\n\"value\": \"54 mV/dec\"\n}\n\n}\n\n}\n\nIf the string is missing certain information such as 'mass_activity', ‘reaction_type’, ‘value’ or 'current_density', your output should not include those keys.\n\nIf there are no values corresponding to the mentioned performance metrics in the input, simply extract the catalyst name as shown below.\n\n{\n\u201dcatalyst_name\": {}\n}\n\nNote: The output should be a JSON object with keys for only the present metrics."},
+            {"role": "system", "content": "this task is to take a string as input and convert it to json format. I want to extract the performance below. [reaction_type, versus, overpotential, substrate, loading, tafel_slope, onset_potential, current_density, BET, specific_activity, mass_activity, surface_area, ECSA, apparent_activation_energy, water_splitting_potential, potential, Rs, Rct, Cdl, TOF, stability, electrolyte, exchange_current_density, onset_overpotential]. If there is information about overpotential and Tafel slope in the input, the output should be generated as follows.\n\n{\n\u201dligand_name\": {\n\"overpotential\": {\n\"electrolyte\": \"1.0 M KOH\",\n\"reaction_type\": \"OER\",\n\"value\": \"230 mV\",\n\"current_density\": \"50 mA/cm2\"\n},\n\"tafel_slope\": {\n\"electrolyte\": \"1.0 M KOH\",\n\"reaction_type\": \"OER\",\n\"value\": \"54 mV/dec\"\n}\n\n}\n\n}\n\nIf information regarding the reaction_type or electrolyte cannot be found in the input, they should not be included in the output as follows.\n\n{\n\u201dligand_name\": {\n\"overpotential\": {\n\"value\": \"230 mV\",\n\"current_density\": \"50 mA/cm2\"\n},\n\"tafel_slope\": {\n\"value\": \"54 mV/dec\"\n}\n\n}\n\n}\n\nIf the string is missing certain information such as 'mass_activity', ‘reaction_type’, ‘value’ or 'current_density', your output should not include those keys.\n\nIf there are no values corresponding to the mentioned performance metrics in the input, simply extract the ligand name as shown below.\n\n{\n\u201dligand_name\": {}\n}\n\nNote: The output should be a JSON object with keys for only the present metrics."},
             {"role": "user", "content": str(loaded_data_string)}
             ]
         )
@@ -62,7 +62,7 @@ def few_shot(input_path, output_path) :
     Returns:
     json : prediction of table data extraction
     """        
-    client = OpenAI(api_key=  "User key")
+    client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
     file_list = os.listdir(input_path)
     for file_name in file_list : 
         with open(input_path + file_name, 'r', encoding='utf-8') as file:
@@ -73,7 +73,7 @@ def few_shot(input_path, output_path) :
             frequency_penalty=0,
             presence_penalty=0,
             messages=[
-            {"role": "system", "content": "I will extract the performance information of the catalyst from the table and create a JSON format. The types of performance to be extracted will be given as a list: performance_list = [overpotential, tafel_slope, Rct, stability, Cdl, onset_potential, current_density, potential, TOF, ECSA, water_splitting_potential, mass_activity, exchange_current_density, Rs, specific_activity, onset_overpotential, BET, surface_area, loading, apparent_activation_energy]. You can only use the names as they are in the performance_list, and any changes to the names in the performance_list, no matter how slight, are not allowed. The JSON format will have performance within the catalyst, and each performance will include elements present in the table: reaction type, value, electrolyte, condition, current density, versus(ex: RHE) and substrate. Other elements must not be included in performance. Be very strict. The output must contain only json dictionary. Other sentences or opinion must not be in output."},
+            {"role": "system", "content": "I will extract ligand data from the table and create a JSON format. The JSON should follow: LIGAND_TEMPLATE = {'ligand_name': {PROPERTY_TEMPLATE}}. PROPERTY_TEMPLATE = {'chemical_formula': '', 'specific_area': '', 'pzc': '', 'water_contact_angle': '', 'initial_uranium_concentration': '', 'adsorbent_amount': '', 'solution_volume': '', 'adsorbent_solution_ratio': '', 'adsorption_amount': '', 'adsorption_time': ''}. Use only the keys from PROPERTY_TEMPLATE and do not modify their names. The output must contain only JSON."},
             
             # X I/O PAIRS
             {"role": "user", "content":''},
@@ -128,7 +128,7 @@ def zero_shot(input_path, output_path) :
     json : prediction of table data extraction
     """    
     
-    client = OpenAI(api_key = 'User key')
+    client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
     file_list = os.listdir(input_path)
 
     for file in file_list :
@@ -139,24 +139,24 @@ def zero_shot(input_path, output_path) :
 
         table_name = file.split('.')[0]
 
-        instruction = "I'm going to convert the information in the table representer into JSON format.\n CATALYST_TEMPLATE = {'catalyst_name' : {'performance_name' : {PROPERTY_TEMPLATE}}\n PROPERTY_TEMPLATE = {'electrolyte': '', 'reaction_type': '', 'value': '', 'current_density': '', 'overpotential': '',  'potential': '','substrate': '', 'versus':''}\n performance_list = [overpotential, tafel_slope, Rct, stability, Cdl, onset_potential, current_density, potential, TOF, ECSA, water_splitting_potential, mass_activity, exchange_current_density, Rs, specific_activity, onset_overpotential, BET, surface_area, loading, apparent_activation_energy]\n. Table representer is in below \n\n "
-        result = {"catalysts":[]}
+        instruction = "I'm going to convert the information in the table representer into JSON format.\n LIGAND_TEMPLATE = {'ligand_name': {PROPERTY_TEMPLATE}}\n PROPERTY_TEMPLATE = {'chemical_formula': '', 'specific_area': '', 'pzc': '', 'water_contact_angle': '', 'initial_uranium_concentration': '', 'adsorbent_amount': '', 'solution_volume': '', 'adsorbent_solution_ratio': '', 'adsorption_amount': '', 'adsorption_time': ''}\n Table representer is in below \n\n "
+        result = {"ligands":[]}
 
         message_ = [{"role": "system", "content": instruction + table_representer}]
 
-        catalyst_q = "Show the catalysts present in the table representer as a Python list. Answer must be ONLY python list. Not like '''python ''' Be very very very strict. Other sentences or explanation is not allowed.\n"
-        question = catalyst_q
+        ligand_q = "Show the ligands present in the table representer as a Python list. Answer must be ONLY python list. Not like '''python ''' Be very very very strict. Other sentences or explanation is not allowed.\n"
+        question = ligand_q
         message_.append({"role": "user", "content": question})
         _, cata_answer = prompt(message_) 
-        catalyst_list = eval(cata_answer)
+        ligand_list = eval(cata_answer)
         data['question'].append(copy(message_))
         data['answer'].append(cata_answer)
 
         message_.append({"role": "assistant", "content": cata_answer}) # 다음 prompt에 이전 답 추가
 
-        for catalyst in catalyst_list : 
+        for ligand in ligand_list : 
 
-            performance_template_q = "Create a CATALYST_TEMPLATE filling in the performance of {catalyst}  from the table representer, strictly adhering to the following 3 rules:\n\n Rule 1: Only include the actual existing performances from the Performance_list in the CATALYST_TEMPLATE.\n Rule 2: Set all values of the keys in PROPERTY_TEMPLATE to be " ". DO NOT INSERT ANY VALUE. BE VERY STRICT.\n Rule 3: Answer must be ONLY json format. Only display the JSON (like string not ```json). Other sentences or explanation is not allowed.".format(catalyst="'''"+catalyst+"'''")
+            performance_template_q = "Create a LIGAND_TEMPLATE filling in the properties of {ligand}  from the table representer, strictly adhering to the following 3 rules:\n\n Rule 1: Use only the keys in PROPERTY_TEMPLATE.\n Rule 2: Set all values of the keys in PROPERTY_TEMPLATE to be " ". DO NOT INSERT ANY VALUE. BE VERY STRICT.\n Rule 3: Answer must be ONLY json format. Only display the JSON (like string not ```json). Other sentences or explanation is not allowed.".format(ligand="'''"+ligand+"'''")
             question = performance_template_q
             message_.append({"role": "user", "content": question})
             _, perfo_answer = prompt(message_)
@@ -169,12 +169,11 @@ def zero_shot(input_path, output_path) :
             question = property_q
             message_.append({"role": "user", "content": question})
             _, property_answer1 = prompt(message_)
-
+            property_title_caption_q = "Modify the previous version of LIGAND_TEMPLATE based solely on the title and caption. Never modify the keys. Fill in values only for keys that appear in the title or caption."
             data['question'].append(copy(message_)) 
             data['answer'].append(property_answer1)
                 
             message_.append({"role": "assistant", "content": property_answer1})
-            property_title_caption_q = "Modify the previous version of CATALYST_TEMPLATE based solely on the title, caption according to the rules below. Only refer to the title and caption part in table representer. Strictly adhere to the following rules. \n Rule 1: If there is reaction type information in title or caption, reflect the reaction type in previous version of CATALYST_TEMPLATE accordingly. But if there isn't reaction type information in title or caption part, leave CATALYST_TEMPLATE as previous version. Be strict. \n Rule 2: If there is electrolyte information in title or caption part, reflect the electrolyte in previous version of CATALYST_TEMPLATE. But if there isn't electrolyte information in title or caption part, leave CATALYST_TEMPLATE as previous version. Be strict. \n Rule 3: Never modify the keys.  \n Rule 4: Never fill in values for any other keys except reaction_type, electrolyte. Never delete any other keys or value."
             question = property_title_caption_q
             message_.append({"role": "user", "content": question})
             _, property_answer2 = prompt(message_) 
@@ -183,7 +182,7 @@ def zero_shot(input_path, output_path) :
             data['answer'].append(property_answer2)
 
             message_.append({"role": "assistant", "content": property_answer1})
-            delete_q ='Remove keys with no values from previous version of CATALYST_TEMPLATE.'
+            delete_q ='Remove keys with no values from previous version of LIGAND_TEMPLATE.'
             question = delete_q
             message_.append({"role": "user", "content": question})
             _, delete_answer = prompt(message_)
@@ -191,17 +190,17 @@ def zero_shot(input_path, output_path) :
             data['question'].append(copy(message_))
             data['answer'].append(delete_answer)
             
-            catalyst_template = json.loads(delete_answer)
-            result["catalysts"].append(catalyst_template)
+            ligand_template = json.loads(delete_answer)
+            result["ligands"].append(ligand_template)
             
             message_ = [{"role": "system", "content": instruction + table_representer}]
-            message_.append({"role": "user", "content": catalyst_q})
+            message_.append({"role": "user", "content": ligand_q})
             message_.append({"role": "assistant", "content": cata_answer})
             
-        if len(result["catalysts"]) == 1 : 
-            final_result = result["catalysts"][0]
+        if len(result["ligands"]) == 1 :
+            final_result = result["ligands"][0]
 
-        elif len(result["catalysts"]) > 1 : 
+        elif len(result["ligands"]) > 1 :
             final_result = result
         try :     
             with open(output_path +  table_name + ".json", "w") as json_file:

--- a/MaTableGPT-main/README.md
+++ b/MaTableGPT-main/README.md
@@ -20,12 +20,17 @@ conda env create -f requirements_conda.txt
 ```bash
 pip install -r requirements_paper.txt
 ```
-### 2) Download data files
+### 2) Environment variable
+Set your OpenAI API key using `OPENAI_API_KEY`:
+```bash
+export OPENAI_API_KEY=YOUR_KEY
+```
+### 3) Download data files
 ```
 git clone https://github.com/KIST-CSRC/MaTableGPT.git
 git lfs pull
 ```
-## 3) Script architecture
+## 4) Script architecture
 ```
 MaTableGPT
 ├── data
@@ -47,7 +52,7 @@ MaTableGPT
 │ 
 └── run.py
 ```
-### 4) Code usage (run.py)
+### 5) Code usage (run.py)
 **Examples : Input generation (split, tsv)**
 > ```python
 > input_generation("split", "TSV")

--- a/MaTableGPT-main/run.py
+++ b/MaTableGPT-main/run.py
@@ -131,5 +131,6 @@ def model_test(model_, fq):
     print("[MODEL_TEST] input_path:", input_path, "| output_path:", output_path)
     
 
-input_generation("split", "TSV")
-model_test("few_shot", True)
+if __name__ == "__main__":
+    input_generation("split", "TSV")
+    model_test("few_shot", True)


### PR DESCRIPTION
## Summary
- switch API key handling to OPENAI_API_KEY env var
- add docs for OPENAI_API_KEY in README
- guard run.py execution with a `__main__` block
- update prompts and JSON templates for ligand extraction

## Testing
- `python -m py_compile MaTableGPT-main/GPT_models/models.py MaTableGPT-main/GPT_models/follow_up_q.py MaTableGPT-main/run.py`

------
https://chatgpt.com/codex/tasks/task_e_686b49e0b4fc832ba639fb31ee9a9349